### PR TITLE
ignore __pycache__ dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore any path containing '__pycache__'
+__pycache__


### PR DESCRIPTION
This should ignore any `__pycache__` dirs at any level of the tree, and
stop the churn of constantly updating them in each commit made by GitHub
Actions.

After this is merged we can clean up existing `__pycache__` files.